### PR TITLE
Use fork of `nflows`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -21,7 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
-    - name: Run integration tests with pytest
+        pip install .[dev]
+    - name: Run (quick) integration tests
       run: |
-        pytest -m "integration_test or slow_integration_test"
+        pytest -v tests/ -m "integration_test"
+    - name: Run slow integration tests
+      run: |
+        pytest -v tests/ -m "slow_integration_test"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   integration-tests:
-    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    name: Python ${{ matrix.python-version }} nflows=${{ matrix.use-nflows }} (${{ matrix.os }})
 
     strategy:
       fail-fast: false
@@ -37,6 +37,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+    - name: Optionally install nflows
+      if: ${{ matrix.use-nflows }}
+      run: |
+        pip install nflows
+    - name: Set nflows version
+      run: |
+        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $env:GITHUB_ENV
+    - name: Print environment variables
+      run: |
+        env
     - name: Run integration tests (fast)
       run: |
         python -m pytest -m "integration_test"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,13 +15,14 @@ concurrency:
 
 jobs:
   integration-tests:
-    name: Python ${{ matrix.python-version }} nflows=${{ matrix.use-nflows }} (${{ matrix.os }})
+    name: Python ${{ matrix.python-version }} (nflows=${{ matrix.use-nflows }}) (${{ matrix.os }})
 
     strategy:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        use-nflows: [True, False]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Run (quick) integration tests
       run: |
         pytest -v tests/ -m "integration_test"
-    - name: Run slow integration tests
-      run: |
-        pytest -v tests/ -m "slow_integration_test"
+    # - name: Run slow integration tests
+    #  run: |
+    #    pytest -v tests/ -m "slow_integration_test"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
         pip install nflows
     - name: Set nflows version
       run: |
-        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $env:GITHUB_ENV
+        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $GITHUB_ENV
     - name: Print environment variables
       run: |
         env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout repository and submodules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-        pip install .[dev]
+        pip install -e .[dev]
     - name: Lint with flake8
       run: |
         flake8 .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
 
     steps:
     - name: Checkout repository and submodules
-    - uses: actions/checkout@v2
-    - with:
+      uses: actions/checkout@v2
+      with:
         submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,10 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
+    - name: Checkout repository and submodules
     - uses: actions/checkout@v2
+    - with:
+        submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-        pip install -e .[dev]
+        pip install .[dev]
     - name: Lint with flake8
       run: |
         flake8 .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   unittests:
-    name: Python ${{ matrix.python-version }} nflows=${{ matrix.use-nflows }} (${{ matrix.os }})
+    name: Python ${{ matrix.python-version }} (nflows=${{ matrix.use-nflows }}) (${{ matrix.os }})
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,14 @@ concurrency:
 
 jobs:
   unittests:
-    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    name: Python ${{ matrix.python-version }} nflows=${{ matrix.use-nflows }} (${{ matrix.os }})
 
     strategy:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        use-nflows: [True, False]
     runs-on: ${{ matrix.os }}-latest
 
     steps:
@@ -37,6 +38,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+    - name: Optionally install nflows
+      if: ${{ matrix.use-nflows }}
+      run: |
+        pip install nflows
+    - name: Set nflows version
+      run: |
+        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $env:GITHUB_ENV
+    - name: Print environment variables
+      run: |
+        env
     - name: Test with pytest
       run: |
         python -m pytest --without-integration --without-slow-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         pip install nflows
     - name: Set nflows version
       run: |
-        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $env:GITHUB_ENV
+        echo "GLASFLOW_USE_NFLOWS=${{ matrix.use-nflows }}" >> $GITHUB_ENV
     - name: Print environment variables
       run: |
         env

--- a/.github/workflows/tests_nflows_fork.yml
+++ b/.github/workflows/tests_nflows_fork.yml
@@ -1,0 +1,38 @@
+name: Check nflows fork
+
+on:
+  push:
+    branches: [ main, release*]
+  schedule:
+    # Run tests at 7:00 UTC everyday
+    - cron: '0 7 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-nflows:
+    name: Test (${{ matrix.os }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS, Ubuntu, Windows]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[nflows-test]
+    - name: Test with pytest
+      run: |
+        python -m pytest submodules/nflows

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/nflows"]
+	path = submodules/nflows
+	url = git@github.com:igr-ml/nflows.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/nflows"]
 	path = submodules/nflows
-	url = git@github.com:igr-ml/nflows.git
+	url = https://github.com/igr-ml/nflows.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,13 @@
 
 To install `glasflow` and contribute clone the repo and install the additional dependencies with:
 
-```console
-$ cd glasflow
-$ pip install .[dev]
+```shell
+pip install -e .[dev,nflows]
 ```
 
-**Note:** Make sure the submodules are update, see the [git documentation on submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for details.
+**Note:** Make sure the submodules are up-to-date, see the [git documentation on submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for details.
 
-**Note:** because of a long-standing bug in `setuptools` ([#230](https://github.com/pypa/setuptools/issues/230)), editable installs (`pip install -e`) are not supported by older versions of `setuptools`. Editable installs require `setuptools>=64.0.3`.
+**Note:** because of a long-standing bug in `setuptools` ([#230](https://github.com/pypa/setuptools/issues/230)), editable installs (`pip install -e`) are not supported by older versions of `setuptools`. Editable installs require `setuptools>=64.0.3`. You may also require an up-to-date version of `pip`.
 
 ## Format checking
 
@@ -19,10 +18,10 @@ We use [pre-commit](https://pre-commit.com/) to re-format code using `black` and
 
 This requires some setup:
 
-```console
-$ pip install pre-commit # Should already be installed
-$ cd glasflow
-$ pre-commit install
+```shell
+pip install pre-commit # Should already be installed
+cd glasflow
+pre-commit install
 ```
 
 Now we you run `$ git commit` `pre-commit` will run a series of checks. Some checks will automatically change the code and others will print warnings that you must address and re-commit.
@@ -34,13 +33,28 @@ When contributing code to `glasflow` please ensure that you also contribute corr
 The tests can be run from the root directory using
 
 ```console
-$ pytest
+pytest
 ```
 
 Specific tests can be run using
 
 ```console
-$ pytest tests/test_<name>.py
+pytest tests/test_<name>.py
 ```
 
+**Note:** the configuration for `pytest` is pulled from `pyproject.toml`
+
 See the `pytest` [documentation](https://docs.pytest.org/) for further details on how to write tests using `pytest`.
+
+### Testing with nflows
+
+The continuous integration in glasflow tests with the environment variable `GLASFLOW_USE_NFLOWS` set to `True` and `False` independently. We recommend running the test suite with both values prior opening a pull request. For example:
+
+```console
+$ export GLASFLOW_USE_NFLOWS=false
+$ pytest
+...
+$ export GLASFLOW_USE_NFLOWS=true
+$ pytest
+...
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,12 @@ To install `glasflow` and contribute clone the repo and install the additional d
 
 ```console
 $ cd glasflow
-$ pip install -e .[dev]
+$ pip install .[dev]
 ```
+
+**Note:** Make sure the submodules are update, see the [git documentation on submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for details.
+
+**Note:** because of a long-standing bug in `setuptools` ([#230](https://github.com/pypa/setuptools/issues/230)), editable installs (`pip install -e`) are not supported.
 
 ## Format checking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ $ pip install .[dev]
 
 **Note:** Make sure the submodules are update, see the [git documentation on submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for details.
 
-**Note:** because of a long-standing bug in `setuptools` ([#230](https://github.com/pypa/setuptools/issues/230)), editable installs (`pip install -e`) are not supported.
+**Note:** because of a long-standing bug in `setuptools` ([#230](https://github.com/pypa/setuptools/issues/230)), editable installs (`pip install -e`) are not supported by older versions of `setuptools`. Editable installs require `setuptools>=64.0.3`.
 
 ## Format checking
 

--- a/README.md
+++ b/README.md
@@ -4,28 +4,20 @@ glasflow is a Python library containing a collection of [Normalizing flows](http
 
 ## Installation
 
-To install from github:
+To install from GitHub:
 
-```bash
-pip install git+https://github.com/igr-ml/glasflow.git
+```shell
+$ pip install git+https://github.com/igr-ml/glasflow.git
 ```
-
-## nflows
-
-glasflow uses a fork of nflows which is included as submodule in glasflow and can used imported as follows:
-
-```python
-import glasflow.nflows as nflows
-```
-
-It contains various bugfixes which, as of writing this, are not included in current release of `nflows`.
 
 ## PyTorch
+
 By default the version of PyTorch will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
 
 ## Usage
 
 To define a RealNVP flow:
+
 ```python
 from glasflow.flows import RealNVP
 
@@ -40,7 +32,28 @@ flow = RealNVP(
 
 Please see [glasflow/examples](https://github.com/igr-ml/glasflow/tree/main/examples) for a typical training regime example.
 
-## Contributing
-Pull requests are welcome. You can review the contribution guidelines [here](https://github.com/igr-ml/glasflow/blob/main/CONTRIBUTING.md). For major changes, please open an issue first to discuss what you would like to change.
+## nflows
 
-Please make sure to update tests as appropriate.
+glasflow uses a fork of nflows which is included as submodule in glasflow and can used imported as follows:
+
+```python
+import glasflow.nflows as nflows
+```
+
+It contains various bugfixes which, as of writing this, are not included in current release of `nflows`.
+
+### Using standard nflows
+
+There is also the option to use an independent install of nflows (if installed) by setting an environment variable.
+
+```shell
+export  GLASFLOW_USE_NFLOWS=True
+```
+
+After setting this variable `glasflow.nflows` will point to the version of nflows installed in the current python environment.
+
+**Note:** this must be set prior to importing glasflow.
+
+## Contributing
+
+Pull requests are welcome. You can review the contribution guidelines [here](https://github.com/igr-ml/glasflow/blob/main/CONTRIBUTING.md). For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ After setting this variable `glasflow.nflows` will point to the version of nflow
 ## Contributing
 
 Pull requests are welcome. You can review the contribution guidelines [here](https://github.com/igr-ml/glasflow/blob/main/CONTRIBUTING.md). For major changes, please open an issue first to discuss what you would like to change.
+
+## Citing
+
+If you use glasflow in your work we recommend you also cite nflows following the guidelines in the [nflows readme](https://github.com/igr-ml/nflows#citing-nflows).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ To install from github:
 pip install git+https://github.com/igr-ml/glasflow.git
 ```
 
+## nflows
+
+glasflow uses a fork of nflows which is included as submodule in glasflow and can used imported as follows:
+
+```python
+import glasflow.nflows as nflows
+```
+
+It contains various bugfixes which, as of writing this, are not included in current release of `nflows`.
+
 ## PyTorch
-By default the version of PyTroch will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
+By default the version of PyTorch will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ build-backend = "setuptools.build_meta"
 line-length = 79
 target-version = ['py36', 'py37', 'py38', 'py39']
 
+[tool.pytest.ini_options]
+testpaths = [
+    "tests"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm[toml]"]
+requires = ["setuptools>=64.0.3", "wheel", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 79
 target-version = ['py36', 'py37', 'py38', 'py39']
+exclude = ["submodules"]
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ install_requires =
 [options.extras_require]
 nflows = 
     nflows
+nflows-test = 
+    torchtestcase
+    UMNN
 dev =
     black
     pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,12 +15,13 @@ classifiers =
 keywords = normalising flows, machine learning
 
 [options]
-package_dir=
-    =src
-packages = find:
+package_dir = 
+    glasflow = src/glasflow
+    glasflow.nflows = submodules/nflows/nflows
 python requires = >=3.6
-install_requires =
-    nflows
+install_requires = 
+    numpy
+    torch
 test_suite = tests
 tests_require =
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ install_requires =
 nflows = 
     nflows
 nflows-test = 
+    pytest
+    pytest-rerunfailures
     torchtestcase
     UMNN
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ long_description_content_type = text/markdown
 author = IGR-ML
 url = https://github.com/igr-ml/glasflow
 classifiers =
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -18,7 +17,7 @@ keywords = normalising flows, machine learning
 package_dir = 
     glasflow = src/glasflow
     glasflow.nflows = submodules/nflows/nflows
-python requires = >=3.6
+python requires = >=3.7
 install_requires = 
     numpy
     torch

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ dev =
     pytest-integration
 
 [flake8]
+exclude = submodules
 ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 79
 max-complexity = 18

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ dev =
     pytest-integration
 
 [flake8]
-exclude = submodules
+exclude = submodules, build
 ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 79
 max-complexity = 18

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,12 @@ package_dir =
     glasflow.nflows = submodules/nflows/nflows
 python requires = >=3.7
 install_requires =
+    numpy
     torch
-    nflows
-
-[options.packages.find]
-where=src
 
 [options.extras_require]
+nflows = 
+    nflows
 dev =
     black
     pre-commit

--- a/src/glasflow/__init__.py
+++ b/src/glasflow/__init__.py
@@ -9,7 +9,28 @@ Code is hosted at: https://github.com/igr-ml/glasflow
 
 nflows: https://github.com/bayesiains/nflows
 """
-from .flows import (
+import os
+
+USE_NFLOWS = os.environ.get("GLASFLOW_USE_NFLOWS", "False").lower() in [
+    "true",
+    "1",
+]
+if USE_NFLOWS:
+    print("glasflow is using `nflows` instead of the included submodule")
+    import sys
+
+    try:
+        import nflows
+    except ModuleNotFoundError:
+        raise RuntimeError(
+            "nflows is not installed. Set the environment variable "
+            "`GLASFLOW_USE_NFLOWS=False` to use the included fork of nflows."
+        )
+    sys.modules["glasflow.nflows"] = nflows
+else:
+    print("glasflow is using the included fork of `nflows`")
+
+from .flows import (  # noqa
     CouplingNSF,
     RealNVP,
 )

--- a/src/glasflow/__init__.py
+++ b/src/glasflow/__init__.py
@@ -69,6 +69,10 @@ except ImportError:  # for Python < 3.8
 
 try:
     __version__ = version(__name__)
+    if USE_NFLOWS:
+        __version__ += "+nflows-ext"
+    else:
+        __version__ += "+nflows-int"
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/src/glasflow/flows/coupling.py
+++ b/src/glasflow/flows/coupling.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from nflows.nn.nets import ResidualNet
-from nflows import transforms
-from nflows.transforms.coupling import CouplingTransform
+from glasflow.nflows.nn.nets import ResidualNet
+from glasflow.nflows import transforms
+from glasflow.nflows.transforms.coupling import CouplingTransform
 import torch
 import torch.nn.functional as F
 
@@ -126,7 +126,7 @@ class CouplingFlow(Flow):
                 transforms_list.append(transforms.BatchNorm(n_inputs))
 
         if distribution is None:
-            from nflows.distributions import StandardNormal
+            from glasflow.nflows.distributions import StandardNormal
 
             distribution = StandardNormal([n_inputs])
 

--- a/src/glasflow/flows/nsf.py
+++ b/src/glasflow/flows/nsf.py
@@ -4,7 +4,7 @@ Implementation of Neural Spline Flows.
 
 See: https://arxiv.org/abs/1906.04032
 """
-from nflows.transforms.coupling import (
+from glasflow.nflows.transforms.coupling import (
     PiecewiseRationalQuadraticCouplingTransform,
 )
 from .coupling import CouplingFlow

--- a/src/glasflow/flows/realnvp.py
+++ b/src/glasflow/flows/realnvp.py
@@ -2,7 +2,7 @@
 """
 Implementation of RealNVP.
 """
-from nflows.transforms.coupling import (
+from glasflow.nflows.transforms.coupling import (
     AdditiveCouplingTransform,
 )
 from .coupling import CouplingFlow

--- a/src/glasflow/transforms/coupling.py
+++ b/src/glasflow/transforms/coupling.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Alternative implementations of coupling transforms"""
-from nflows.transforms.coupling import (
+from glasflow.nflows.transforms.coupling import (
     AffineCouplingTransform as BaseAffineCouplingTransform,
 )
 import torch.nn.functional as F

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""
+General configuration for tests.
+"""
+import glasflow
+
+
+def pytest_sessionstart():
+    """Log which nflows backend is being using"""
+    print(f"glasflow config: USE_NFLOWS={glasflow.USE_NFLOWS}")

--- a/tests/test_flows/test_coupling.py
+++ b/tests/test_flows/test_coupling.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from glasflow.flows.coupling import CouplingFlow
-from glasflow.nflows.transforms import AffineCouplingTransform
+from glasflow.nflows.transforms.coupling import AffineCouplingTransform
 import torch
 
 import pytest

--- a/tests/test_flows/test_coupling.py
+++ b/tests/test_flows/test_coupling.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+
 from glasflow.flows.coupling import CouplingFlow
-from nflows.transforms import AffineCouplingTransform
+from glasflow.nflows.transforms import AffineCouplingTransform
 import torch
 
 import pytest

--- a/tests/test_flows/test_realnvp.py
+++ b/tests/test_flows/test_realnvp.py
@@ -12,6 +12,7 @@ def test_coupling_flow_init(volume_preserving):
 
 
 @pytest.mark.integration_test
+@pytest.mark.flaky(reruns=5)
 def test_realnvp_wide_scale():
     """Test RealNVP with the 'wide' scaling method"""
     flow = RealNVP(2, 2, scaling_method="wide")

--- a/tests/test_transforms/test_coupling_transforms.py
+++ b/tests/test_transforms/test_coupling_transforms.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from torch._C import Value
 from glasflow.transforms.coupling import AffineCouplingTransform
 import pytest
 import torch
@@ -15,7 +14,7 @@ def affine_transform():
 
 
 @pytest.mark.parametrize("scaling_method", ["nflows", "wide"])
-@patch("nflows.transforms.coupling.AffineCouplingTransform.__init__")
+@patch("glasflow.nflows.transforms.coupling.AffineCouplingTransform.__init__")
 def test_affine_init(mock, affine_transform, scaling_method):
     """Assert the init method pass inputs to the parent class"""
     mask = [1, -1]
@@ -32,7 +31,7 @@ def test_affine_init(mock, affine_transform, scaling_method):
     assert affine_transform.scaling_method == scaling_method
 
 
-@patch("nflows.transforms.coupling.AffineCouplingTransform.__init__")
+@patch("glasflow.nflows.transforms.coupling.AffineCouplingTransform.__init__")
 def test_affine_init_invalid_scaling(mock, affine_transform):
     """Assert an error is raised if an invalid scaling method is passed"""
     mask = [1, -1]
@@ -67,7 +66,7 @@ def test_scale_and_shift_nflows(affine_transform):
     params = "params"
     affine_transform.scaling_method = "nflows"
     with patch(
-        "nflows.transforms.coupling.AffineCouplingTransform._scale_and_shift"
+        "glasflow.nflows.transforms.coupling.AffineCouplingTransform._scale_and_shift"
     ) as mock:
         AffineCouplingTransform._scale_and_shift(affine_transform, params)
     mock.assert_called_once_with(params)


### PR DESCRIPTION
This PR reworks `glasflow` to use a custom fork of `nflows` (https://github.com/igr-ml/nflows) which includes bugfixes that aren't included in the current master.

**Details**

I opted to include our own version of `nflows` as a submodule of `glasflow` so that you can import it (similar to `jax.numpy`):

```python
import glasflow.nflows as nflows
```
This allows us to use our own version of `nflows` without having to release it separately and it also doesn't interfere with any existing installs a user might have.

The source code is included as git submodule in `submodules/nflows` and gets packaged up when creating a wheel.

**Things to note**

* ~~I had to use `package_dir` in `setup.cfg` to get this to work. Unfortunately, this means that `pip install -e .` no longer works because of a bug in `setuptools` (https://github.com/pypa/setuptools/issues/230).~~ This is now fixed!
* `nflows` is no longer a requirement for `glasflow`

**To-Do**

- [x] Fix CI
- [x] Test installation in a clean environment
- [x] More tests to make sure the version of `nflows` is stable.
- [x] Check what is included in the wheel/build and use manifest to exclude unnecessary files
