### PR TITLE
Specify all args and kwargs

### DIFF
--- a/src/glasflow/flows/nsf.py
+++ b/src/glasflow/flows/nsf.py
@@ -7,19 +7,42 @@ See: https://arxiv.org/abs/1906.04032
 from glasflow.nflows.transforms.coupling import (
     PiecewiseRationalQuadraticCouplingTransform,
 )
+import torch.nn.functional as F
 from .coupling import CouplingFlow
 
 
 class CouplingNSF(CouplingFlow):
     """Implementation of Neural Spline Flows using a coupling transform.
 
-    See :obj:`glasflow.flow.coupling.CouplingFlow` for the complete list of
-    parameters and methods.
-
     Parameters
     ----------
-    args :
-        Positional arguments passed to the parent class.
+    n_inputs : int
+        Number of inputs
+    n_transforms : int
+        Number of transforms
+    n_conditional_inputs: int
+        Number of conditionals inputs
+    n_neurons : int
+        Number of neurons per residual block in each transform
+    n_blocks_per_transform : int
+        Number of residual blocks per transform
+    batch_norm_within_blocks : bool
+        Enable batch normalisation within each residual block
+    batch_norm_between_transforms : bool
+        Enable batch norm between transforms
+    activation : function
+        Activation function to use. Defaults to ReLU
+    dropout_probability : float
+        Amount of dropout to apply. 0 being no dropout and 1 being drop
+        all connections
+    linear_transform : str, {'permutation', 'lu', 'svd', None}
+        Linear transform to apply before each coupling transform.
+    distribution : :obj:`nflows.distribution.Distribution`
+        Distribution object to use for that latent spae. If None, an n-d
+        Gaussian is used.
+    mask : Union[torch.Tensor, list, numpy.ndarray]
+        Mask or array of masks to use to construct the flow. If not specified,
+        an alternating binary mask will be used.
     num_bins : int
         Number of bins for the spline in each dimension.
     tail_type : {None, 'linear'}
@@ -29,16 +52,43 @@ class CouplingNSF(CouplingFlow):
         Bound that defines the region over which the splines are defined.
         I.e. [-tail_bound, tail_bound]
     kwargs :
-        Keyword arguments passed to the parent class.
+        Keyword arguments passed to the transform when is it initialised.
     """
 
     def __init__(
-        self, *args, num_bins=4, tail_type="linear", tail_bound=5.0, **kwargs
+        self,
+        n_inputs,
+        n_transforms,
+        n_conditional_inputs=None,
+        n_neurons=32,
+        n_blocks_per_transform=2,
+        batch_norm_within_blocks=False,
+        batch_norm_between_transforms=False,
+        activation=F.relu,
+        dropout_probability=0.0,
+        linear_transform=None,
+        distribution=None,
+        mask=None,
+        num_bins=4,
+        tail_type="linear",
+        tail_bound=5.0,
+        **kwargs,
     ):
         transform_class = PiecewiseRationalQuadraticCouplingTransform
         super().__init__(
             transform_class,
-            *args,
+            n_inputs,
+            n_transforms,
+            n_conditional_inputs=n_conditional_inputs,
+            n_neurons=n_neurons,
+            n_blocks_per_transform=n_blocks_per_transform,
+            batch_norm_within_blocks=batch_norm_within_blocks,
+            batch_norm_between_transforms=batch_norm_between_transforms,
+            activation=activation,
+            dropout_probability=dropout_probability,
+            linear_transform=linear_transform,
+            distribution=distribution,
+            mask=mask,
             num_bins=num_bins,
             tails=tail_type,
             tail_bound=tail_bound,

--- a/src/glasflow/flows/realnvp.py
+++ b/src/glasflow/flows/realnvp.py
@@ -5,6 +5,7 @@ Implementation of RealNVP.
 from glasflow.nflows.transforms.coupling import (
     AdditiveCouplingTransform,
 )
+import torch.nn.functional as F
 from .coupling import CouplingFlow
 from ..transforms import AffineCouplingTransform
 
@@ -14,25 +15,77 @@ class RealNVP(CouplingFlow):
 
     See: https://arxiv.org/abs/1605.08803
 
-    See :obj:`glasflow.flow.coupling.CouplingFlow` for the complete list of
-    parameters and methods.
-
     Parameters
     ----------
-    args :
-        Positional arguments passed to the parent class.
+    n_inputs : int
+        Number of inputs
+    n_transforms : int
+        Number of transforms
+    n_conditional_inputs: int
+        Number of conditionals inputs
+    n_neurons : int
+        Number of neurons per residual block in each transform
+    n_blocks_per_transform : int
+        Number of residual blocks per transform
+    batch_norm_within_blocks : bool
+        Enable batch normalisation within each residual block
+    batch_norm_between_transforms : bool
+        Enable batch norm between transforms
+    activation : function
+        Activation function to use. Defaults to ReLU
+    dropout_probability : float
+        Amount of dropout to apply. 0 being no dropout and 1 being drop
+        all connections
+    linear_transform : str, {'permutation', 'lu', 'svd', None}
+        Linear transform to apply before each coupling transform.
+    distribution : :obj:`nflows.distribution.Distribution`
+        Distribution object to use for that latent spae. If None, an n-d
+        Gaussian is used.
+    mask : Union[torch.Tensor, list, numpy.ndarray]
+        Mask or array of masks to use to construct the flow. If not specified,
+        an alternating binary mask will be used.
     volume_preserving : bool, optional
         If True use additive transforms that preserve volume.
     kwargs :
-        Keyword arguments passed to the parent class which in turn passes any
-        kwargs to the transform class which will be either
+        Keyword arguments passed to either
         :py:obj:`nflows.transforms.coupling.AdditiveCouplingTransform` or
         :py:obj:`glasflow.transforms.coupling.AffineCouplingTransform`.
     """
 
-    def __init__(self, *args, volume_preserving=False, **kwargs):
+    def __init__(
+        self,
+        n_inputs,
+        n_transforms,
+        n_conditional_inputs=None,
+        n_neurons=32,
+        n_blocks_per_transform=2,
+        batch_norm_within_blocks=False,
+        batch_norm_between_transforms=False,
+        activation=F.relu,
+        dropout_probability=0.0,
+        linear_transform=None,
+        distribution=None,
+        mask=None,
+        volume_preserving=False,
+        **kwargs,
+    ):
         if volume_preserving:
             transform_class = AdditiveCouplingTransform
         else:
             transform_class = AffineCouplingTransform
-        super().__init__(transform_class, *args, **kwargs)
+        super().__init__(
+            transform_class,
+            n_inputs,
+            n_transforms,
+            n_conditional_inputs=n_conditional_inputs,
+            n_neurons=n_neurons,
+            n_blocks_per_transform=n_blocks_per_transform,
+            batch_norm_within_blocks=batch_norm_within_blocks,
+            batch_norm_between_transforms=batch_norm_between_transforms,
+            activation=activation,
+            dropout_probability=dropout_probability,
+            linear_transform=linear_transform,
+            distribution=distribution,
+            mask=mask,
+            **kwargs,
+        )


### PR DESCRIPTION
This makes it clearer what the args and kwargs are when using the flows.

Previously when checking the doc-string in an editor, the user would only see `*args` and would have to refer to the documentation for the parent class. This could be confusing for new users.

This also allows us to have different defaults for splines and RealNVP