### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,7 +12,6 @@ jobs:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
       with:
-        lfs: true
         submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
Try and fix the publishing workflow (again)

I tracked down the source of the issues with LFS int the `publish-to-pypi` workflow to an issue in the nflows submodule. The example Jupyter notebooks were meant to be committed with git LFS but the two examples weren't. When cloning the repo with LFS the notebooks were being pulled as pointers rather than files, leading to the dirty state of the repo.

I've opted to just remove the examples since they're not necessary and this allows us to avoid any files with LFS.