### PR TITLE
Set torch version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
 python requires = >=3.7
 install_requires =
     numpy
-    torch
+    torch>=1.11.0
 
 [options.extras_require]
 nflows = 


### PR DESCRIPTION
Require torch>=1.11.0 because `torch.linalg.triangular_solve` is required and was added in that release.