### PR TITLE
Update readme & license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 MIT License
 
-Copyright (c) 2021-2022 Jordan McGinn, Federico Stachurski, Michael J. Williams
+Copyright (c) 2021-2022 Jordan McGinn, Federico Stachurski, John Veitch, Michael J. Williams
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ glasflow is a Python library containing a collection of [Normalizing flows](http
 
 ## Installation
 
-To install from GitHub:
+glasflow is available to install via `pip`:
 
 ```shell
-$ pip install git+https://github.com/igr-ml/glasflow.git
+pip install glasflow
+```
+
+or via `conda`:
+
+```shell
+conda install glasflow -c conda-forge
 ```
 
 ## PyTorch
 
-By default the version of PyTorch will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
+By default the version of PyTorch installed by `pip` or `conda` will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ By default the version of PyTorch installed by `pip` or `conda` will not necessa
 To define a RealNVP flow:
 
 ```python
-from glasflow.flows import RealNVP
+from glasflow import RealNVP
 
-# define RealNVP flow. Change hyperparameters as nessesary.
+# define RealNVP flow. Change hyperparameters as necessary.
 flow = RealNVP(
     n_inputs=2,
     n_transforms=5,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ conda install glasflow -c conda-forge
 
 ## PyTorch
 
-By default the version of PyTorch installed by `pip` or `conda` will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: https://pytorch.org/.
+**Important:** `nessai` supports using CUDA devices but it is not a requirement and in most uses cases it provides little to no benefit.
+
+By default the version of PyTorch installed by `pip` or `conda` will not necessarily match the drivers on your system, to install a different version with the correct CUDA support see the PyTorch homepage for instructions: <https://pytorch.org/>.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Pull requests are welcome. You can review the contribution guidelines [here](htt
 
 ## Citing
 
-If you use glasflow in your work we recommend you also cite nflows following the guidelines in the [nflows readme](https://github.com/igr-ml/nflows#citing-nflows).
+If you use glasflow in your work please cite [our DOI](https://doi.org/10.5281/zenodo.7108558). We also recommend you also cite nflows following the guidelines in the [nflows readme](https://github.com/igr-ml/nflows#citing-nflows).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7108558.svg)](https://doi.org/10.5281/zenodo.7108558)
+[![PyPI](https://img.shields.io/pypi/v/glasflow)](https://pypi.org/project/glasflow/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/glasflow.svg)](https://anaconda.org/conda-forge/glasflow)
+
 # Glasflow
 
 glasflow is a Python library containing a collection of [Normalizing flows](https://arxiv.org/abs/1912.02762) using [PyTorch](https://pytorch.org). It builds upon [nflows](https://github.com/bayesiains/nflows).


### PR DESCRIPTION
Update the readme now that `glasflow` is available to install via `pip` and `conda`.

Also update the license to include John.

**Changes**
* Update installation instructions
* Add badges
* Update "citing" to include the DOI
* Tweak usage instructions and fix typo
* Add John to the license

