### PR TITLE
Fix broken nflows fork CI

### DIFF
--- a/.github/workflows/tests_nflows_fork.yml
+++ b/.github/workflows/tests_nflows_fork.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The CI that checks the fork on nflows used in glasflow is broken because it has now defaulted to Python 3.11 but PyTorch doesn't support it yet. So this PR just pins the Python version to 3.10.
