### PR TITLE
Update black pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 21.7b0
+  rev: 22.6.0
   hooks:
   - id: black
-    language_version: python3.8
+    language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2 
   hooks:


### PR DESCRIPTION
Update the version of the black used in the pre-commit to fix an issue with click 8.1.0