### PR TITLE
Tweak output on import

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ dev =
     pytest
     pytest-cov
     pytest-integration
+    pytest-requires
     pytest-rerunfailures
 examples = 
     ipykernel

--- a/src/glasflow/__init__.py
+++ b/src/glasflow/__init__.py
@@ -10,9 +10,12 @@ Code is hosted at: https://github.com/igr-ml/glasflow
 nflows: https://github.com/bayesiains/nflows
 """
 import importlib.util
+import logging
 import os
 import pkgutil
 import sys
+
+logger = logging.getLogger(__name__)
 
 
 def _import_submodules(module):
@@ -41,7 +44,9 @@ USE_NFLOWS = os.environ.get("GLASFLOW_USE_NFLOWS", "False").lower() in [
     "1",
 ]
 if USE_NFLOWS:
-    print("glasflow is using an externally installed version of nflows")
+    logger.warning(
+        "glasflow is using an externally installed version of nflows"
+    )
     if not NFLOWS_INSTALLED:
         raise RuntimeError(
             "nflows is not installed. Set the environment variable "
@@ -55,7 +60,7 @@ if USE_NFLOWS:
     # the nflows installation
     _import_submodules(nflows)
 else:
-    print("glasflow is using its own internal version of nflows")
+    logger.info("glasflow is using its own internal version of nflows")
 
 from .flows import (  # noqa
     CouplingNSF,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Test importing glasflow"""
+from importlib import reload
+import os
+
+import glasflow
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reload_glasflow():
+    """Make sure nessai is reloaded after these tests"""
+    original_version = glasflow.__version__
+    use_nflows_default = os.environ.get("GLASFLOW_USE_NFLOWS", None)
+    yield
+    if use_nflows_default is None:
+        os.environ.pop("GLASFLOW_USE_NFLOWS")
+    else:
+        os.environ["GLASFLOW_USE_NFLOWS"] = use_nflows_default
+    assert os.environ.get("GLASFLOW_USE_NFLOWS") == use_nflows_default
+    reload(glasflow)
+    assert glasflow.__version__ == original_version
+
+
+@pytest.mark.requires("nflows")
+@pytest.mark.integration_test
+def test_glasflow_use_external_nflows(caplog):
+    """Assert in the import works with the external version of nflows"""
+    os.environ["GLASFLOW_USE_NFLOWS"] = "True"
+    reload(glasflow)
+    assert "using an externally installed version" in str(caplog.text)
+
+
+@pytest.mark.integration_test
+def test_glasflow_use_internal_nflows(caplog):
+    """Assert the import works with the internal version of nflows"""
+    caplog.set_level("INFO")
+    os.environ["GLASFLOW_USE_NFLOWS"] = "False"
+    reload(glasflow)
+    assert "using its own internal version" in str(caplog.text)


### PR DESCRIPTION
Motivated by https://github.com/igr-ml/glasflow/issues/41, I'm proposing a change to the messages that are reported when importing `glasflow`.

Currently, a message is reported irrespective of which version of `nflows` is being used (via `print`). After discussing things with @Rodrigo-Tenorio, I propose we switch to using a logger. This will change when the messages are reported but allow them to be properly logged. 

With these changes, when importing `glasflow`, a message will only be printed if using the external version of nflows (unless a logger has been set up).

**Example of setting up a logger**
If the user wants to capture the output from `glasflow`, they can do something like this:

```python
import logging
# Configure the logger
logger = logging.getLogger("glasflow")
formatter = logging.Formatter(
    "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
    datefmt="%H:%M:%S",
)
stream_handler = logging.StreamHandler()
stream_handler.setFormatter(formatter)
stream_handler.setLevel("INFO")
logger.addHandler(stream_handler)
logger.setLevel("INFO")

import glasflow
```
In future, we should probably document this properly.

**Other changes**
I also added some tests for this